### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/csv2sql21.py
+++ b/csv2sql21.py
@@ -37,7 +37,7 @@ def do_writesample(cnsql, sample):
       cursql.close()
     except mdb.Error, e:
       print "*** MySQL error"
-      print "**** Error %d: %s" % (e.args[0],e.args[1])
+      print "**** Error {0:d}: {1!s}".format(e.args[0], e.args[1])
       if cursql:    # attempt to close connection to MySQLdb
         print "***** Closing cursor"
         cursql.close()
@@ -56,7 +56,7 @@ if __name__ == "__main__":
       print logtext
   except mdb.Error, e:
     print "MySQL error"
-    print "Error %d: %s" % (e.args[0],e.args[1])
+    print "Error {0:d}: {1!s}".format(e.args[0], e.args[1])
     if consql:    # attempt to close connection to MySQLdb
       print "Closing MySQL connection"
       consql.close()

--- a/daemon11.py
+++ b/daemon11.py
@@ -121,5 +121,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon12.py
+++ b/daemon12.py
@@ -137,5 +137,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon13.py
+++ b/daemon13.py
@@ -141,5 +141,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon14.py
+++ b/daemon14.py
@@ -145,5 +145,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon15.py
+++ b/daemon15.py
@@ -133,5 +133,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon19.py
+++ b/daemon19.py
@@ -148,5 +148,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon21.py
+++ b/daemon21.py
@@ -113,12 +113,12 @@ def do_work():
     syslog.syslog(syslog.LOG_ALERT,logmessage)
 
   if (Tamb > 45.0) and succes:
-    logmessage = "*** Ambient temperature too high *** (%s)" % (Tamb)
+    logmessage = "*** Ambient temperature too high *** ({0!s})".format((Tamb))
     if DEBUG:print logmessage
     syslog.syslog(syslog.LOG_INFO,logmessage)
     succes = False
   if (Tamb < 5.0) and succes:
-    logmessage = "*** Ambient temperature too low *** (%s)" % (Tamb)
+    logmessage = "*** Ambient temperature too low *** ({0!s})".format((Tamb))
     if DEBUG:print logmessage
     syslog.syslog(syslog.LOG_INFO,logmessage)
     succes = False
@@ -186,5 +186,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon29.py
+++ b/daemon29.py
@@ -198,5 +198,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon97.py
+++ b/daemon97.py
@@ -33,7 +33,7 @@ class MyDaemon(Daemon):
     except mdb.Error, e:
       if DEBUG:
         print "Unexpected MySQL error"
-        print "Error %d: %s" % (e.args[0],e.args[1])
+        print "Error {0:d}: {1!s}".format(e.args[0], e.args[1])
       if consql:    # attempt to close connection to MySQLdb
         if DEBUG:print "Closing MySQL connection"
         consql.close()
@@ -100,7 +100,7 @@ def do_writesample(cnsql, cmd, sample):
     cursql.close()
   except mdb.Error, e:
     print "*** MySQL error"
-    print "**** Error %d: %s" % (e.args[0],e.args[1])
+    print "**** Error {0:d}: {1!s}".format(e.args[0], e.args[1])
     if cursql:    # attempt to close connection to MySQLdb
       print "***** Closing cursor"
       cursql.close()
@@ -201,5 +201,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon98.py
+++ b/daemon98.py
@@ -133,5 +133,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon99.py
+++ b/daemon99.py
@@ -263,5 +263,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/libdaemon.py
+++ b/libdaemon.py
@@ -33,7 +33,7 @@ class Daemon:
         # exit first parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.1 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.1 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # decouple from parent environment
@@ -48,7 +48,7 @@ class Daemon:
         # exit from second parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.2 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.2 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # redirect standard file descriptors
@@ -64,7 +64,7 @@ class Daemon:
     # write pidfile
     atexit.register(self.delpid)
     pid = str(os.getpid())
-    file(self.pidfile,'w+').write("%s\n" % pid)
+    file(self.pidfile,'w+').write("{0!s}\n".format(pid))
 
   def delpid(self):
     os.remove(self.pidfile)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Mausy5043:ubundiagd?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Mausy5043:ubundiagd?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
